### PR TITLE
Issue 30 - Adding an extra ZIO.fromDBIO overload with execution context

### DIFF
--- a/src/main/scala/slick/interop/zio/syntax.scala
+++ b/src/main/scala/slick/interop/zio/syntax.scala
@@ -5,10 +5,18 @@ import zio.ZIO
 import zio.stream.ZStream
 import zio.interop.reactivestreams._
 
+import scala.concurrent.ExecutionContext
+
 object syntax {
 
   implicit class ZIOObjOps(private val obj: ZIO.type) extends AnyVal {
-    def fromDBIO[R](dbio: DBIO[R]): ZIO[DatabaseProvider, Throwable, R] =
+    def fromDBIO[R](f: ExecutionContext => DBIO[R]): ZIO[DatabaseProvider, Throwable, R] =
+      for {
+        db <- ZIO.accessM[DatabaseProvider](_.get.db)
+        r  <- ZIO.fromFuture(ec => db.run(f(ec)))
+      } yield r
+
+    def fromDBIO[R](dbio: => DBIO[R]): ZIO[DatabaseProvider, Throwable, R] =
       for {
         db <- ZIO.accessM[DatabaseProvider](_.get.db)
         r  <- ZIO.fromFuture(_ => db.run(dbio))

--- a/src/test/scala/slick/interop/zio/tests/ItemRepository.scala
+++ b/src/test/scala/slick/interop/zio/tests/ItemRepository.scala
@@ -5,8 +5,8 @@ import zio.IO
 object ItemRepository {
 
   trait Service {
-
     def add(name: String): IO[Throwable, Long]
     def getById(id: Long): IO[Throwable, Option[Item]]
+    def upsert(name: String): IO[Throwable, Long]
   }
 }

--- a/src/test/scala/slick/interop/zio/tests/SlickItemRepository.scala
+++ b/src/test/scala/slick/interop/zio/tests/SlickItemRepository.scala
@@ -18,6 +18,16 @@ final class SlickItemRepository(db: DatabaseProvider) extends ItemRepository.Ser
 
     ZIO.fromDBIO(query).map(_.headOption).provide(db)
   }
+
+  def upsert(name: String): IO[Throwable, Long] =
+    ZIO.fromDBIO { implicit ec =>
+      (for {
+        itemOpt <- items.filter(_.name === name).result.headOption
+        id      <- itemOpt.fold[DBIOAction[Long, NoStream, Effect.Write]](
+                     (items returning items.map(_.id)) += Item(0L, name)
+                   )(item => (items.map(_.name) update name).map(_ => item.id))
+      } yield id).transactionally
+    }.provide(db)
 }
 
 object SlickItemRepository {
@@ -26,6 +36,6 @@ object SlickItemRepository {
     ZLayer.fromFunctionM { db =>
       val initialize = ZIO.fromDBIO(ItemsTable.table.schema.createIfNotExists)
 
-      initialize.map(_ => new SlickItemRepository(db)).provide(db)
+      initialize.as(new SlickItemRepository(db)).provide(db)
     }
 }

--- a/src/test/scala/slick/interop/zio/tests/SlickItemRepositorySpec.scala
+++ b/src/test/scala/slick/interop/zio/tests/SlickItemRepositorySpec.scala
@@ -2,11 +2,12 @@ package slick.interop.zio.tests
 
 import com.typesafe.config.ConfigFactory
 import slick.interop.zio.DatabaseProvider
-import zio.test.Assertion.equalTo
+import zio.test.Assertion.{ equalTo, isSome, not }
+import zio.test.TestAspect.sequential
 import zio.test._
 import zio.{ ZIO, ZLayer }
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 
 object SlickItemRepositorySpec extends DefaultRunnableSpec {
 
@@ -27,14 +28,27 @@ object SlickItemRepositorySpec extends DefaultRunnableSpec {
     suite("Item repository")(
       testM("Add and get items") {
         for {
-          repo <- ZIO.access[ItemRepository](_.get)
+          repo <- ZIO.service[ItemRepository.Service]
           _    <- repo.add("A")
           _    <- repo.add("B")
           a    <- repo.getById(1L)
           b    <- repo.getById(2L)
-        } yield assert(a.map(_.name))(equalTo(Some("A"))) && assert(b.map(_.name))(equalTo(Some("B")))
+        } yield assert(a.map(_.name))(isSome(equalTo("A"))) &&
+          assert(b.map(_.name))(isSome(equalTo("B")))
+      },
+      testM("Upsert items") {
+        for {
+          repo <- ZIO.service[ItemRepository.Service]
+          cId  <- repo.upsert("C")
+          c    <- repo.getById(cId)
+          cId2 <- repo.upsert("C")
+          c2   <- repo.getById(cId)
+        } yield assert(c.map(_.name))(isSome(equalTo("C"))) &&
+          assert(c2.map(_.name))(isSome(equalTo("C"))) &&
+          assert(cId)(equalTo(cId2)) &&
+          assert(cId)(not(equalTo(1L)))
       }
-    )
+    ) @@ sequential
 
   def spec = specs.provideLayer(env.orDie)
 }


### PR DESCRIPTION
Adding an extra ZIO.fromDBIO overload for DBIO effects requiring an execution context.

Solves [issue 30](https://github.com/ScalaConsultants/zio-slick-interop/issues/30).