### PR TITLE
Update scalafmt to 3.3.1

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,9 +1,11 @@
-version = "2.7.5"
+version = "3.3.1"
 maxColumn = 120
 align.preset = most
 continuationIndent.defnSite = 2
 assumeStandardLibraryStripMargin = true
-docstrings = JavaDoc
+docstrings {
+  style = Asterisk
+}
 lineEndings = preserve
 includeCurlyBraceInSelectChains = false
 spaces {
@@ -12,3 +14,5 @@ spaces {
 optIn.annotationNewlines = true
 
 rewrite.rules = [SortImports, RedundantBraces]
+
+runner.dialect = scala213


### PR DESCRIPTION
scala-steward bot failed to do the update because JavaDoc is deprected.
Since v3.1.0, the runner.dialect parameter is required to be specified explicitly.

This Pr update scalafmt and introduce a dialect

Scalafmt documentation reference https://scalameta.org/scalafmt/docs/configuration.html#docstringsstyle--asterisk

Failed Pr:  https://github.com/ScalaConsultants/zio-slick-interop/pull/95