### PR TITLE
Support creating DatabaseProvider layer from DataSource

### DIFF
--- a/src/test/scala/slick/interop/zio/tests/SlickItemRepositorySpec.scala
+++ b/src/test/scala/slick/interop/zio/tests/SlickItemRepositorySpec.scala
@@ -23,7 +23,7 @@ object SlickItemRepositorySpec extends ZIOSpecDefault {
   private val env: ZLayer[Any, Throwable, ItemRepository] =
     (ZLayer.succeed(config) ++ ZLayer.succeed[JdbcProfile](
       slick.jdbc.H2Profile
-    )) >>> DatabaseProvider.live >>> SlickItemRepository.live
+    )) >>> DatabaseProvider.fromConfig() >>> SlickItemRepository.live
 
   private val specs: Spec[ItemRepository, Throwable] =
     suite("Item repository")(


### PR DESCRIPTION
- add `fromDataSource` factory method for DatabaseProvider
- change name and signature of the `live` layer